### PR TITLE
Encode data sent to a socket

### DIFF
--- a/api/python/mcpi/connection.py
+++ b/api/python/mcpi/connection.py
@@ -35,7 +35,7 @@ class Connection:
         #print "s",s
         self.drain()
         self.lastSent = s
-        self.socket.sendall(s)
+        self.socket.sendall(s.encode())
 
     def receive(self):
         """Receives data. Note that the trailing newline '\n' is trimmed"""


### PR DESCRIPTION
Taken from [the forum post](http://www.raspberrypi.org/forums/viewtopic.php?f=32&t=33349).

No testing set up for this yet but it seems like a sensible assumption `s` will be unicode at this point and `socket.send()` takes bytes.
