### PR TITLE
Should use Enum34 package and add to Travis Build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,16 @@
 #!/usr/bin/env python
 import io
 from setuptools import setup, find_packages
+import sys
 
 with io.open('README.rst', mode='r', encoding='utf8') as f:
     readme = f.read()
+
+
+dependencies = []
+if sys.version_info[:2] < (3, 4):
+    dependencies.append('enum34')
+
 
 setup(name='py3minepi',
       version='0.0.1',
@@ -14,6 +21,7 @@ setup(name='py3minepi',
       include_package_data=True,
       keywords='minecraft raspberry pi mcpi py3minepi',
       long_description=readme,
+      install_requires=dependencies,
       classifiers=[
           'Development Status :: Development Status :: 3 - Alpha',
           'Environment :: X11 Applications',


### PR DESCRIPTION
enum34 is a backport of Python 3.4 for earlier versions of Python.
https://pypi.python.org/pypi/enum34
Should use standard library backport instead of flufl.enum as want to be standard library anyway.
Easily installed with pip-3.2 and python3-pip already in Travis dependencies.
Package would need to be added to Travis config.
