### PR TITLE
Fixed coverage dependency for coveralls

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ commands =
 basepython=python3.2
 deps =
     {[testenv]deps}
-    coverage
+    coverage>=3.6,<3.999
     coveralls
 commands =
     pip install -e .


### PR DESCRIPTION
Coveralls.io doesn't work with coverage >=4. This PR fixes that problem.
