### PR TITLE
Add python 3 compatible rich equality comparison

### DIFF
--- a/mcpi/vec3.py
+++ b/mcpi/vec3.py
@@ -64,6 +64,12 @@ class Vec3:
         if dz != 0: return dz
         return 0
 
+    def __eq__(self, rhs):
+        if self.x == rhs.x and self.y == rhs.y and self.z == rhs.z:
+            return True
+
+        return False
+
     def iround(self): self._map(lambda v:int(v+0.5))
     def ifloor(self): self._map(int)
 


### PR DESCRIPTION
This adds an `__eq__` method to the `Vec3` class so we can do rich comparisons between `Vec3` instances (`a == b`).

The `__cmp__` method was [removed in Python 3](https://docs.python.org/3.0/whatsnew/3.0.html#ordering-comparisons) in favour of methods such as `__eq__`.
