### PR TITLE
Pass options from tox to pytest

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,4 +8,4 @@ envlist =
 deps =
     pytest
 commands =
-    py.test
+    py.test {posargs}


### PR DESCRIPTION
e.g. `tox -- tests/test_vec3.py::TestVec3 -k test_rotate_right`

This is useful for customising the command tox is running. The example above, for instance, only runs the test_rotate_right test in the TestVec3 class.
