### PR TITLE
Run coverage under tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,9 +3,18 @@ envlist =
 	py27,
 	py33,
 	py34,
+    coverage,
 
 [testenv]
 deps =
     pytest
 commands =
     py.test
+
+[testenv:coverage]
+deps =
+    coverage
+    pytest
+commands =
+    coverage run -m pytest --strict
+    coverage report --include=mcpi/*


### PR DESCRIPTION
This adds a coverage test environment to tox to run coverage on the code base via pytest.

Note it only reports on `mcpi` to avoid picking up extra directories like `.tox` and `tests`.
