### PR TITLE
Don't join/leave the irc channel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,4 @@ notifications:
     channels:
       - "chat.freenode.net#py3minepi"
     use_notice: true
+    skip_join: true


### PR DESCRIPTION
This updates the Travis bot behaviour to not join (and thus leave) the IRC channel for each notice it sends.
